### PR TITLE
Create a temporary context for the first middleware to run for not sending content to client if the middleware fail

### DIFF
--- a/middleware.go
+++ b/middleware.go
@@ -16,10 +16,22 @@ func Mixed() func(handler1, handler2 echo.MiddlewareFunc) echo.MiddlewareFunc {
 			a2 := handler2(next)
 
 			return func(c echo.Context) error {
-				if a1(c) == nil {
+				tempContext := copyContext(c)
+				defer tempContext.Echo().ReleaseContext(tempContext)
+				if a1(tempContext) == nil {
+					copyResponse(c, tempContext)
+
 					return nil
 				}
-				return a2(c)
+
+				// Try the second middleware
+				err := a2(c)
+				if err != nil {
+					// Return the first middleware error
+					copyResponse(c, tempContext)
+					c.Response().WriteHeader(tempContext.Response().Status)
+				}
+				return err
 			}
 		}
 	}

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -2,6 +2,7 @@ package mixed
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -24,18 +25,18 @@ func TestMixed(t *testing.T) {
 		{
 			name: "TestMixedAuthenticationSucceedsOnFirstAuth",
 			args: args{
-				mw1: succeedingMiddleware("hello"),
+				mw1: succeedingMiddleware(204),
 				mw2: failingMiddleware(errors.New("boom")),
 			},
-			want: "hello",
+			want: "204",
 		},
 		{
 			name: "TestMixedAuthenticationSucceedsOnSecondAuth",
 			args: args{
 				mw1: failingMiddleware(errors.New("boom")),
-				mw2: succeedingMiddleware("hello2"),
+				mw2: succeedingMiddleware(204),
 			},
-			want: "hello2",
+			want: "204",
 		},
 		{
 			name: "TestMixedAuthenticationFailsOnBothFailedAuths",
@@ -70,7 +71,7 @@ func TestMixed(t *testing.T) {
 					t.Errorf("got %v, want %v", err, tt.wantErr)
 				}
 
-				got = ctx.Get("KEY").(string)
+				got = fmt.Sprint(ctx.Response().Status)
 			}
 
 			if got != tt.want {
@@ -80,10 +81,10 @@ func TestMixed(t *testing.T) {
 	}
 }
 
-func succeedingMiddleware(succeedingValue string) echo.MiddlewareFunc {
+func succeedingMiddleware(status int) echo.MiddlewareFunc {
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c echo.Context) error {
-			c.Set("KEY", succeedingValue)
+			c.NoContent(status)
 			return nil
 		}
 	}

--- a/tempresponsewriter.go
+++ b/tempresponsewriter.go
@@ -1,0 +1,24 @@
+package mixed
+
+import "net/http"
+
+// tempResponseWriter implements the http.ResponseWriter interface
+// It used when you need to temporary hold the content and use it later
+type tempResponseWriter struct {
+	header     http.Header
+	StatusCode int
+	Content    []byte
+}
+
+func (rw *tempResponseWriter) Header() http.Header {
+	return rw.header
+}
+
+func (rw *tempResponseWriter) Write(content []byte) (int, error) {
+	rw.Content = append(rw.Content, content...)
+	return len(content), nil
+}
+
+func (rw *tempResponseWriter) WriteHeader(code int) {
+	rw.StatusCode = code
+}

--- a/utils.go
+++ b/utils.go
@@ -1,0 +1,41 @@
+package mixed
+
+import (
+	"net/http"
+
+	echo "github.com/labstack/echo/v4"
+)
+
+// copyContext creates a new echo.Context with the same Request, Path, Params and Handler
+// but with a Response that contains an in-memory ResponseWriter
+func copyContext(c echo.Context) echo.Context {
+	cc := c.Echo().AcquireContext()
+	cc.SetRequest(c.Request())
+	cc.SetPath(c.Path())
+	cc.SetParamNames(c.ParamNames()...)
+	cc.SetParamValues(c.ParamValues()...)
+	cc.SetHandler(c.Handler())
+
+	rw := tempResponseWriter{
+		header:  make(http.Header),
+		Content: []byte{},
+	}
+	resp := echo.NewResponse(&rw, c.Echo())
+	cc.SetResponse(resp)
+	return cc
+}
+
+// copyResponse copy c2 headers and content into c1
+func copyResponse(c1, c2 echo.Context) {
+	for k, v := range c2.Response().Header() {
+		for _, vv := range v {
+			c1.Response().Header().Set(k, vv)
+		}
+	}
+
+	if c2.Response().Status > 0 {
+		c1.Response().WriteHeader(c2.Response().Status)
+	}
+
+	c1.Response().Write(c2.Response().Writer.(*tempResponseWriter).Content)
+}


### PR DESCRIPTION
Actually, if the first middleware write something in the response, the content is really written (response code, content, header, etc).

The idea is to create a temporary Response for holding the data temporary.
Plus, if the second middleware fail, we send the content of the first one.