### PR TITLE
ci: fix GitHub action

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.go text eol=lf

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -1,30 +1,29 @@
-on: [push, pull_request]
 name: Test
+
+on: [ push, pull_request ]
+
 jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.15.x, 1.16.x, 1.17.x]
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        go-version: [ 1.15, 1.16, 1.17, 1.18, 1.19 ]
+        os: [ ubuntu-latest, macos-latest, windows-latest ]
+
     runs-on: ${{ matrix.os }}
+
     steps:
-    - name: Install Go
-      uses: actions/setup-go@v2
-      with:
-        go-version: ${{ matrix.go-version }}
-    - name: Checkout code
-      uses: actions/checkout@v2
-    - name: Enforce standard format
-      run: |
-        if [ "$RUNNER_OS" == "Linux" ]; then
-          go get -u github.com/golangci/golangci-lint/cmd/golangci-lint@v1.42.1
-          golangci-lint run --tests=false --enable=gofmt -v
-        else
-          echo "$RUNNER_OS not supported"
-          exit 0
-        fi
-      shell: bash
-    - name: Test
-      run: go test --cover -v ./...
-    - name: Build
-      run: go build -v ./...
+      - name: Install Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ matrix.go-version }}
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Enforce standard format
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: v1.50.1
+          args: --tests=false --enable=gofmt -v
+      - name: Test
+        run: go test --cover -v ./...
+      - name: Build
+        run: go build -v ./...


### PR DESCRIPTION
- Use latest version of `actions/checkout` and `actions/setup-go`
- Use GitHub action for `golangci-lint`
- Add latest Go versions

Fixes #19