### PR TITLE
ci: increase golangci-lint timeout

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -22,7 +22,7 @@ jobs:
         uses: golangci/golangci-lint-action@v3
         with:
           version: v1.50.1
-          args: --tests=false --enable=gofmt -v
+          args: --timeout 3m --tests=false --enable=gofmt --verbose
       - name: Test
         run: go test --cover -v ./...
       - name: Build


### PR DESCRIPTION
Increase golangci-lint timeout to 3 minutes as there's a lot of failure due to the 1 minute timeout.
3 minutes seem to be a good default for the Github action (see https://github.com/golangci/golangci-lint-action/issues/297)

