### PR TITLE
build: use go 1.20 and 1.21 in CI

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Enforce standard format
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.50.1
+          version: v1.54.2
           args: --timeout 3m --tests=false --enable=gofmt --verbose
       - name: Test
         run: go test --cover -v ./...

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -6,7 +6,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [ 1.17, 1.18, 1.19 ]
+        go-version: [ "1.18", "1.19", "1.20", "1.21" ]
         os: [ ubuntu-latest, macos-latest, windows-latest ]
 
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
- Test against latest Go version
- Align with echo versions (https://github.com/labstack/echo/blob/master/.github/workflows/echo.yml#L28C45-L28C45)