### PR TITLE
ci: use Go 1.22

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -13,7 +13,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [ "1.17", "1.18", "1.19", "1.20", "1.21" ]
+        go-version: [ "1.19", "1.20", "1.21", "1.22" ]
         os: [ ubuntu-22.04, macos-12, windows-2022 ]
 
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Use Go 1.22 to align with echo https://github.com/labstack/echo/blob/master/.github/workflows/echo.yml#L28