### PR TITLE
chore: bump runners

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         go-version: [ "1.19", "1.20", "1.21", "1.22" ]
-        os: [ ubuntu-22.04, macos-12, windows-2022 ]
+        os: [ ubuntu-22.04, macos-14, windows-2022 ]
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         go-version: [ "1.19", "1.20", "1.21", "1.22" ]
-        os: [ ubuntu-22.04, macos-14, windows-2022 ]
+        os: [ ubuntu-24.04, macos-14, windows-2022 ]
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
- macos-12 is not supported anymore (https://github.com/actions/runner-images/issues/10721)
- ubuntu-24.04 is now the latest version
